### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/dillontrodd/7ba4b028-dd6e-436a-a5f0-11ea76307b9e/a13992ab-d19e-4397-8bc4-aa3b6ea0998e/_apis/work/boardbadge/17a574dc-41fd-4ee1-9e53-f43f1aeaac5a)](https://dev.azure.com/dillontrodd/7ba4b028-dd6e-436a-a5f0-11ea76307b9e/_boards/board/t/a13992ab-d19e-4397-8bc4-aa3b6ea0998e/Microsoft.RequirementCategory)
 # Object


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/dillontrodd/7ba4b028-dd6e-436a-a5f0-11ea76307b9e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.